### PR TITLE
Disable SSH DNS lookup

### DIFF
--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -5,7 +5,7 @@ AddressFamily any
 TCPKeepAlive no
 ClientAliveInterval 600
 ClientAliveCountMax 3
-UseDNS yes
+UseDNS no
 
 # Loggin
 # ===================


### PR DESCRIPTION
# Proposed Changes

This will improve SSH connect speed, as the SSH server won't need to reverse-lookup the incoming address.
Currently it takes few seconds due to this setting, which may fail if DNS set does not have a DNS PTR resolution.

```
reverse mapping checking getaddrinfo for gigaman [192.168.10.3] failed.
```

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/